### PR TITLE
Ensure crudLinks are absolute

### DIFF
--- a/apachesolr_civiAttachments.module
+++ b/apachesolr_civiAttachments.module
@@ -418,11 +418,11 @@ function theme_apachesolr_search_snippets__civiFile($vars) {
 
   foreach ($parents as $entity_table => $items) {
     foreach ($items as $entity_id => $nonce) {
-      $link = CRM_Utils_System::createDefaultCrudLink(array(
+      $link = CRM_Utils_System::createDefaultCrudLink([
         'action' => CRM_Core_Action::VIEW,
         'entity_table' => $entity_table,
         'entity_id' => $entity_id,
-      ));
+      ], TRUE);
       if ($link) {
         $parent_entity_links [] = l($link['title'], $link['url']);
       }


### PR DESCRIPTION
The function `CRM_Utils_System::createDefaultCrudLink` has been updated with a 2nd param, `$absolute`.
It previously made links absolute unconditionally but now must be told to do so.

See https://github.com/civicrm/civicrm-core/pull/18916

I'm not sure whether this module needs them to be absolute (it would only be necessary if installed on a separate domain from the CiviCRM instance) but this PR maintains the status-quo, and is backward compatible so can be merged and deployed prior to upgrading CiviCRM.